### PR TITLE
ci: add github actions pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: Android CI/CD
+
+on:
+  push:
+    branches: [ "master", "phase/*" ]
+  pull_request:
+    branches: [ "master", "phase/*" ]
+
+jobs:
+  build:
+    name: Build & Verify
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        cache: gradle
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+
+    - name: Build with Gradle (CI Verification)
+      run: ./gradlew build
+
+    - name: Build APK (CD Delivery)
+      run: ./gradlew assembleDebug
+
+    - name: Upload APK Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: app-debug
+        path: app/build/outputs/apk/debug/app-debug.apk


### PR DESCRIPTION
Closes #3. Adds CI/CD workflow for Android builds and APK artifacts.