### PR TITLE
chore: fix missing .gitignore entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 /captures
 .externalNativeBuild
 .cxx
+
+.vscode/


### PR DESCRIPTION
## Problem/Goal
The previous chore missed adding the .gitignore entry.

## Closes
Closes #20