### PR TITLE
chore(release): prepare v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.0.2] - 2026-01-15
+### Changed
+- **Governance**: Migrated all operational logic from `standard_workflow.md` to `.cursorrules` for active enforcement.
+- **Rules**: Hardened `.cursorrules` with:
+    - Strict Checkbox ("Definition of Done") Policy.
+    - Post-Merge CI Validation ("Green Master") Policy.
+    - Mandatory `--body-file` usage for GH CLI to prevent formatting errors.
+    - Automatic branch cleanup (`--delete-branch`).
+
+### Removed
+- **Docs**: Deleted redundant `.agent/workflows/standard_workflow.md`.
+
 ## [v1.0.1] - 2026-01-11
 ### Fixed
 - **Build System**: Upgraded Gradle to 8.5 and AGP to 8.2.2 for modern JDK support (Issue #14).


### PR DESCRIPTION
## Summary
Prepares release v1.0.2 by updating the changelog with recent governance changes.

## Closes
Closes #24

## Testing
- [x] Manual verification (commands + output):
  > Verified CHANGELOG.md content via `git diff`.
  > Verified no unrelated files via `git status`.

## Risk/Rollback
Docs only. Revertible.
