### PR TITLE
chore: configure VS Code to use JDK 21

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,5 @@ captures/
 .externalNativeBuild
 .cxx/
 
-.vscode/
+
 .cursorrules

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive",
+    "java.jdt.ls.java.home": "C:\\Program Files\\Microsoft\\jdk-21.0.9.10-hotspot"
+}


### PR DESCRIPTION
## Configure VS Code to Use JDK 21

The VS Code Gradle extension was failing because it uses the system `JAVA_HOME` (JDK 25) rather than the project configuration.

### 🛠 Changes
- Removed `.vscode/` from `.gitignore` to allow tracking workspace settings.
- Added `java.jdt.ls.java.home` to `.vscode/settings.json` pointing to JDK 21.

### ✅ Effect
- VS Code will now use JDK 21 for the Gradle extension, resolving the build failures.

### Closes
Closes #56
