### PR TITLE
docs(overview): add permissions section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,20 @@ The project follows a **Clean Architecture** approach with a single Shared Modul
 3.  Ensure the scheme is set to `iosApp`.
 4.  Run on a Simulator or Device.
 
+## 🔒 Permissions
+
+To ensure the SOS functionality works as intended, the application requires the following permissions:
+
+### 🤖 Android
+*   **Location** (`ACCESS_FINE_LOCATION`, `ACCESS_COARSE_LOCATION`): Used to attach accurate coordinates to emergency alerts.
+*   **SMS** (`SEND_SMS`): Used to send the SOS message directly to your emergency contacts.
+
+### 🍎 iOS
+*   **Location** (`NSLocationWhenInUseUsageDescription`): Required to access your current location for alerts.
+
+### 🖥️ Desktop
+*   **Location**: MacOS and Windows may prompt to allow location access for the application to function correctly.
+
 ## 🛠 Tech Stack
 *   **Language**: Kotlin 2.0+
 *   **UI**: Jetpack Compose / Compose Multiplatform


### PR DESCRIPTION
## Summary
Added a "Permissions" section to the README.md to document required permissions for Android (Location, SMS), iOS (Location), and Desktop.

## Closes
Closes #60

## Testing
- [ ] Unit tests passed
- [ ] Manual verification (commands + output):
  > Verified README.md content rendering.

## Risk/Rollback
Low risk. Documentation update only. Rollback via revert.
