### PR TITLE
docs(readme): clarify iOS platform status

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,18 @@ The project follows a **Clean Architecture** approach with a single Shared Modul
 1.  Open the terminal.
 2.  Run: `./gradlew :composeApp:run`
 
-### iOS (macOS Only)
+### iOS (macOS Only) — 🚧 Structure Ready
+
+> **Note:** The KMP shared framework compiles for iOS targets, but the native SwiftUI app is not yet implemented. iOS development requires macOS + Xcode, which is not available in this environment.
+>
+> **What's complete:** Shared Kotlin code, `expect/actual` platform abstractions, framework export configuration.
+>
+> **What's needed:** Swift/SwiftUI app to consume the `Shared.framework`.
+
+Once a Mac is available:
 1.  Navigate to `iosApp/`.
 2.  Open `iosApp.xcodeproj` in Xcode.
-3.  Ensure the scheme is set to `iosApp`.
+3.  Implement the SwiftUI app consuming `Shared.framework`.
 4.  Run on a Simulator or Device.
 
 ## 🔒 Permissions


### PR DESCRIPTION
## Summary
Clarifies iOS platform status in README.md for transparency with recruiters and contributors. The native SwiftUI app is not yet implemented; iOS development requires macOS.

## Closes
Closes #62

## Testing
- [x] Markdown renders correctly
- [x] CHANGELOG already says "(structure ready)" — no update needed

## Risk/Rollback
Documentation-only change. Revert if wording is inaccurate.
