### PR TITLE
security: resolve 22 dependabot alerts via resolution strategy

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,3 +12,33 @@ plugins {
 tasks.register("clean", Delete::class) {
     delete(rootProject.buildDir)
 }
+
+allprojects {
+    configurations.all {
+        resolutionStrategy {
+            // Fixes CVE-2023-44487 (HTTP/2 Rapid Reset) and others
+            force("io.netty:netty-codec-http2:4.1.108.Final")
+            force("io.netty:netty-handler:4.1.108.Final")
+            force("io.netty:netty-codec-http:4.1.108.Final")
+            force("io.netty:netty-codec:4.1.108.Final")
+            force("io.netty:netty-common:4.1.108.Final")
+            // Fixes CVE-2024-25710 (Loop with corrupted DUMP) & CVE-2024-26308 (OOM)
+            force("org.apache.commons:commons-compress:1.26.0")
+            // Fixes CVE-2024-24549 (DoS)
+            force("com.google.protobuf:protobuf-java:3.25.3")
+            // Fixes CVE-2023-44483 (DoS)
+            force("org.bitbucket.b_c:jose4j:0.9.6")
+            
+            eachDependency {
+                // Fixes CVE-2024-29857 (ECC Excessive Allocation) and others
+                if (requested.group == "org.bouncycastle") {
+                    useVersion("1.78")
+                }
+                // Ensure all strict Netty modules use the safe version
+                if (requested.group == "io.netty") {
+                    useVersion("4.1.108.Final")
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Forces safe versions for vulnerable transitive dependencies (`io.netty`, `org.bouncycastle`, `commons-compress`) using Gradle `resolutionStrategy`. This resolves 22 Dependabot alerts.

## Closes
Closes #68

## Testing
- [ ] **Remote Verification:** Verified via GitHub Actions CI (since local network blocks artifact downloads).
- [ ] Dependency tree check (via CI logs if possible, or assumed safe if build passes).

## Risk/Rollback
Medium risk: forcing versions could restart incompatibility. If build fails, revert and investigate specific conflict.
