### PR TITLE
docs(changelog): v2.1.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v2.1.0] - 2026-01-27
+### Added
+- **Build**: Android Release Signing configuration (protected by `local.properties`).
+- **Build**: Windows Desktop Packaging (MSI) via `nativeDistributions` configuration.
+- **Build**: ProGuard updated to 7.5.0 to support JDK 21.
+
 ## [v2.0.1] - 2026-01-27
 ### Security
 - **Dependabot**: Resolved 22 transitive dependency alerts involving Netty, BouncyCastle, and others via Gradle `resolutionStrategy` constraints (Issue #76).


### PR DESCRIPTION
## Summary
Added `v2.1.0` release notes to CHANGELOG.md.

## Closes
Closes #87 (docs)

## Testing
- [x] Verified markdown rendering.
