### PR TITLE
chore(security): add keystore to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,6 @@ captures/
 .cursorrules
 .kotlin/
 
-# Keystore
+# Keystore (never commit!)
 *.jks
+*.keystore


### PR DESCRIPTION
## Summary
Added `*.keystore` pattern to `.gitignore` to prevent accidentally committing signing credentials.

## Closes
Closes #103

## Testing
- [x] Manual verification:
  > `git status` shows keystore files as ignored.

## Risk/Rollback
None. Security improvement.
