### PR TITLE
docs+chore: fix correct roadmap, badges, and version sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # SafeLink (KMP Edition)
 
+![Build Status](https://github.com/millenniumsingha/Safelink/actions/workflows/ci.yml/badge.svg)
+![CodeQL](https://github.com/millenniumsingha/Safelink/actions/workflows/codeql.yml/badge.svg)
+![Coverage](https://img.shields.io/badge/coverage-pending-lightgrey)
+
 SafeLink is a cross-platform personal safety application built with **Kotlin Multiplatform (KMP)** and **Compose Multiplatform**. It allows users to manage emergency contacts and send SOS alerts with their location.
 
 ## 📚 Documentation
@@ -66,5 +70,6 @@ To ensure the SOS functionality works as intended, the application requires the 
 | Milestone | Description | Status |
 |-----------|-------------|--------|
 | **v2.0** | KMP Migration — Android, Desktop, iOS framework | ✅ Complete |
-| **v2.1** | iOS Native App — SwiftUI integration | 🚧 Pending (requires macOS) |
+| **v2.1** | Release Signing + Windows Packaging | ✅ Complete |
+| **v2.2** | iOS Native App — SwiftUI integration | 🚧 Pending (requires macOS) |
 | **v3.0** | Cloud Sync & Auth — Cross-device backup | 📋 Planned |

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -96,8 +96,8 @@ android {
         applicationId = "com.safelink.app"
         minSdk = libs.versions.android.minSdk.get().toInt()
         targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = 3
+        versionName = "2.1.0"
     }
     buildTypes {
         getByName("release") {
@@ -120,7 +120,7 @@ compose.desktop {
         nativeDistributions {
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
             packageName = "SafeLink"
-            packageVersion = "1.0.0"
+            packageVersion = "2.1.0"
         }
         buildTypes.release.proguard {
             version.set("7.5.0")


### PR DESCRIPTION
## Summary
- Docs: Updated README with CI/coverage badges and corrected roadmap to match v2.1.0 release reality.
- Versions: Synced Android (`versionCode 3`, `versionName "2.1.0"`) and Desktop (`packageVersion "2.1.0"`) versions.

## Closes
Closes #105
Closes #106

## Testing
- [x] Manual: Verified README preview
- [x] Manual: Verified `build.gradle.kts` syntax
