### PR TITLE
test: add kover code coverage

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.kotlinMultiplatform) apply false
     alias(libs.plugins.sqldelight) apply false
+    id("org.jetbrains.kotlinx.kover") version "0.8.3" apply false
 }
 
 tasks.register("clean", Delete::class) {

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.sqldelight)
+    id("org.jetbrains.kotlinx.kover")
 }
 
 kotlin {


### PR DESCRIPTION
## Summary
Added Kover (Kotlin Coverage) plugin to the project.
- Applied `org.jetbrains.kotlinx.kover` version `0.8.3` to root and shared modules.
- Verification: ran `./gradlew koverHtmlReport` and generated report at `shared/build/reports/kover/html/index.html`.

## Closes
Closes #113

## Testing
- [x] `./gradlew koverHtmlReport` passes
- [x] Report file exists
