### PR TITLE
docs: align README and CHANGELOG with releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v2.1.2] - 2026-02-02
+### Added
+- **Testing**: Unit test infrastructure with `commonTest` and `ContactTest`.
+- **Testing**: Android integration tests (`androidInstrumentedTest`) with `ContactLocalDataSourceTest`.
+- **Testing**: Code coverage via Kover plugin (`koverHtmlReport`).
+- **CI**: Automated unit test and coverage report generation on every push.
+- **Governance**: GitHub Issue Templates (Bug Report, Feature Request).
+- **Governance**: Pull Request Template with checklist.
+
+### Changed
+- **README**: Added CI/Coverage badges and corrected roadmap.
+- **Versions**: Synced Android (`2.1.0`) and Desktop (`2.1.0`) package versions.
+
+## [v2.1.1] - 2026-02-02
+### Added
+- **Release**: Signed Android APK attached to GitHub Release.
+- **Release**: Windows MSI installer attached to GitHub Release.
+
 ## [v2.1.0] - 2026-01-27
 ### Added
 - **Build**: Android Release Signing configuration (protected by `local.properties`).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Build Status](https://github.com/millenniumsingha/Safelink/actions/workflows/ci.yml/badge.svg)
 ![CodeQL](https://github.com/millenniumsingha/Safelink/actions/workflows/codeql.yml/badge.svg)
-![Coverage](https://img.shields.io/badge/coverage-pending-lightgrey)
+![Coverage](https://img.shields.io/badge/coverage-enabled-brightgreen)
 
 SafeLink is a cross-platform personal safety application built with **Kotlin Multiplatform (KMP)** and **Compose Multiplatform**. It allows users to manage emergency contacts and send SOS alerts with their location.
 
@@ -71,5 +71,7 @@ To ensure the SOS functionality works as intended, the application requires the 
 |-----------|-------------|--------|
 | **v2.0** | KMP Migration — Android, Desktop, iOS framework | ✅ Complete |
 | **v2.1** | Release Signing + Windows Packaging | ✅ Complete |
+| **v2.1.1** | Release Assets (APK + MSI) | ✅ Complete |
+| **v2.1.2** | Tests + Coverage + CI Integration | ✅ Complete |
 | **v2.2** | iOS Native App — SwiftUI integration | 🚧 Pending (requires macOS) |
 | **v3.0** | Cloud Sync & Auth — Cross-device backup | 📋 Planned |


### PR DESCRIPTION
## Summary
Aligned README and CHANGELOG with actual GitHub Releases.

### README Changes
- Coverage badge: `pending` → `enabled` (green)
- Roadmap: Added v2.1.1 (Release Assets) and v2.1.2 (Tests + CI)

### CHANGELOG Changes
- Added **v2.1.2** entry (Unit Tests, Integration Tests, Coverage, CI, Templates)
- Added **v2.1.1** entry (Signed APK + MSI attached)

## Closes
Closes #119

## Testing
- [x] Manual review of README
- [x] Manual review of CHANGELOG
