### PR TITLE
docs: update documentation for v2.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v2.1.2] - 2026-02-02
+## [v2.1.3] - 2026-02-02
 ### Added
 - **Testing**: Unit test infrastructure with `commonTest` and `ContactTest`.
 - **Testing**: Android integration tests (`androidInstrumentedTest`) with `ContactLocalDataSourceTest`.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,6 @@ To ensure the SOS functionality works as intended, the application requires the 
 | **v2.0** | KMP Migration — Android, Desktop, iOS framework | ✅ Complete |
 | **v2.1** | Release Signing + Windows Packaging | ✅ Complete |
 | **v2.1.1** | Release Assets (APK + MSI) | ✅ Complete |
-| **v2.1.2** | Tests + Coverage + CI Integration | ✅ Complete |
+| **v2.1.3** | Tests + Coverage + CI Integration | ✅ Complete |
 | **v2.2** | iOS Native App — SwiftUI integration | 🚧 Pending (requires macOS) |
 | **v3.0** | Cloud Sync & Auth — Cross-device backup | 📋 Planned |


### PR DESCRIPTION
Updated README and CHANGELOG to reflect v2.1.3 release (replaces stale v2.1.2 references).