### PR TITLE
fix(ci): add clean step to clear stale Kotlin metadata cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
 
+    - name: Clean Kotlin metadata (fix cache issues)
+      run: ./gradlew clean
+
     - name: Build with Gradle (CI Verification)
       run: ./gradlew build
 


### PR DESCRIPTION
## Summary
Added \./gradlew clean\ step before build to clear stale Kotlin metadata cache causing KLIB ABI version mismatch.

## Closes
Closes #126