### PR TITLE
fix: add java.sql module to MSI for JDBC support

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -124,6 +124,9 @@ compose.desktop {
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
             packageName = "SafeLink"
             packageVersion = "2.3.0"
+            
+            // Include java.sql module for SQLDelight JDBC driver
+            modules("java.sql")
         }
         buildTypes.release.proguard {
             version.set("7.5.0")


### PR DESCRIPTION
## Summary
Added `modules("java.sql")` to `nativeDistributions` config to include the JDBC module in the jlink runtime.

## Problem
MSI installer failed to launch with:
- "java/sql/DriverManager" error
- "Failed to launch JVM" error

## Root Cause
The `java.sql` module (required by SQLDelight JDBC driver) was not included in the jlink runtime image.

## Fix
Added `modules("java.sql")` to the `nativeDistributions` block.

Closes #131
